### PR TITLE
docs: add CLAUDE.md guidance file for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+    "permissions": {
+      "allow": ["Read", "Edit", "Write", "Glob", "Grep", "Bash"],
+      "deny": []
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the **AWS Containers Retail Store Sample App** — a polyglot microservices retail demo
+managed as an [Nx](https://nx.dev/) monorepo. It is intended for **educational purposes only and
+not for production use**.
+
+The application is deliberately over-engineered into multiple decoupled components, each with its
+own language, framework, and persistence backend, so it can be run across different container
+orchestration technologies (Docker Compose, Kubernetes, etc.).
+
+## Repository structure
+
+Each service lives under `src/`:
+
+| Service  | Path           | Language / Stack           | Build / test tool |
+| -------- | -------------- | -------------------------- | ----------------- |
+| ui       | `src/ui`       | Java (Spring)              | Maven (`pom.xml`) |
+| cart     | `src/cart`     | Java (DynamoDB)            | Maven (`pom.xml`) |
+| orders   | `src/orders`   | Java                       | Maven (`pom.xml`) |
+| catalog  | `src/catalog`  | Go                         | `go` / `Makefile` |
+| checkout | `src/checkout` | Node (NestJS / TypeScript) | yarn + Nx + Jest  |
+
+Other notable directories:
+
+- `src/app` — the runnable full-stack Docker Compose project (see [Running the app](#running-the-app)).
+- `src/e2e` — Cypress end-to-end tests.
+- `src/load-generator` — load-generation utility.
+- `terraform/` — deployment targets for EKS / ECS / App Runner.
+- `docs/` — feature and architecture documentation.
+
+## Common commands
+
+The [Nx](https://nx.dev/) build system provides a consistent interface across all projects. Run it
+via `yarn nx`. Every application service carries the `service` tag.
+
+```bash
+yarn install                                   # install dependencies (run from the repo root)
+
+yarn nx build <service>                         # build a single component
+yarn nx test <service>                          # run unit tests for a component
+yarn nx test:integration <service>              # run integration tests for a component
+yarn nx lint <service>                          # lint a component
+yarn nx serve <service>                         # run a component locally on port 8080
+yarn nx container <service>                     # build a container image
+
+yarn nx run-many -t test --projects=tag:service # run a target across all services
+```
+
+To mirror CI, use `affected` against the base branch:
+
+```bash
+yarn nx affected --targets=build --base origin/main --parallel 1
+yarn nx affected --targets=lint,test:integration,test --base origin/main
+```
+
+### Per-service builds and tests
+
+Prefer running the check for the service you changed:
+
+- **checkout (Node):** from `src/checkout`, run `yarn install`, then `yarn build`, `yarn lint`, or
+  `yarn test`. The unit `test` script is currently a no-op (`exit 0`); the meaningful tests are
+  `test:integration` (Jest e2e).
+- **catalog (Go):** from `src/catalog`, run `go build ./...` and `go test ./...` (or the `Makefile`
+  targets if present).
+- **ui / cart / orders (Java):** from the service directory, run `mvn -q -B verify` (or `mvn test`)
+  when a JDK and Maven are available.
+
+## Running the app
+
+The runnable compose stack lives under `src/app` and requires a database password:
+
+```bash
+DB_PASSWORD='<choose-a-password>' yarn compose:up   # docker compose up --build --detach --wait
+```
+
+Then open the UI at http://localhost:8080. Tear it down with:
+
+```bash
+yarn compose:down
+```
+
+The stack brings up the five services plus their backing stores (MySQL/MariaDB, Redis,
+DynamoDB-local); give it 1–2 minutes to become healthy. Note that the **root**
+`docker-compose.yaml` alone is not the full runnable app — use the `src/app` project above.
+
+## Conventions
+
+- **Scope changes tightly.** Touch only the service(s) a task concerns; do not refactor across
+  services or edit unrelated code.
+- **Match existing per-service conventions.** Java follows the existing package/style; TypeScript
+  is formatted with Prettier (`.prettierrc`) and linted with ESLint.
+- **Formatting is enforced.** A Prettier pre-commit hook (via [`devenv`](https://devenv.sh/) /
+  git-hooks) runs in CI. Run Prettier before committing so new/changed files stay formatted.
+- **Do not modify** deployment or infrastructure unless a task explicitly requires it:
+  `terraform/`, Helm charts, `docker-compose*.yaml`, `.github/`, `release-please-config.json`,
+  `renovate.json`.
+- **Commits and PR titles** must follow the [Conventional Commits](https://www.conventionalcommits.org/)
+  format (e.g. `feat:`, `fix:`, `chore:`, `docs:`) — a semantic PR-title check runs in CI.
+
+## CI checks
+
+Pull requests to `main` run (see `.github/workflows/`):
+
+- **Semantic Pull Request** (`pr.yaml`) — the PR title must be a valid Conventional Commit.
+- **Hooks** (`pr.yaml`) — `devenv test`, which runs the pre-commit hooks (Prettier, `gofmt`,
+  Terraform format/lint, sample-data sync).
+- **Project tests** (`pr.yaml`) — `nx affected` build, lint, `test`, `test:integration`, and
+  container targets for the projects touched by the change.
+- **E2E Test** (`e2e-test.yml`) — Docker Compose and Kubernetes (kind) end-to-end tests.

--- a/DEV-DEPLOYMENT.md
+++ b/DEV-DEPLOYMENT.md
@@ -1,0 +1,33 @@
+# Dev deployment — retail-store-sample-app
+
+How to stand up a local dev instance of the app. (The SDE Agent reads this for context; today it
+only auto-runs the root `docker-compose.yaml`, so for anything more, follow the steps below.)
+
+## Full stack via Docker Compose
+
+The runnable compose lives under `src/app` and requires a database password:
+
+```bash
+DB_PASSWORD='<choose-a-password>' \
+  docker compose --project-directory src/app up --build --detach --wait --wait-timeout 120
+# or: DB_PASSWORD='...' yarn compose:up
+```
+
+Then open the UI at http://localhost:8080. Tear down with:
+
+```bash
+docker compose --project-directory src/app down     # or: yarn compose:down
+```
+
+## Services
+
+Brought up by the compose stack: **ui** (Java, the web front end), **catalog** (Go), **cart**
+(Java), **orders** (Java), **checkout** (Node/NestJS), plus their backing stores (MySQL/MariaDB,
+Redis, DynamoDB-local). The UI depends on the four APIs; give the stack ~1–2 min to become healthy.
+
+## Notes
+
+- Requires Docker with the compose v2 plugin, run in privileged mode (the SDE Agent build is).
+- `DB_PASSWORD` is mandatory and has no default — the stack fails to start without it.
+- The root `docker-compose.yaml` alone is not the full runnable app; use `--project-directory src/app`.
+- Deploy targets for EKS/ECS/App Runner live under `terraform/` — out of scope for local dev.

--- a/SDE-AGENT.md
+++ b/SDE-AGENT.md
@@ -63,3 +63,13 @@ This is an Nx monorepo. Prefer running the check for the service you changed:
 - The change addresses the task and nothing more.
 - The relevant service builds; the relevant tests run (and you report what you ran + the outcome).
 - No secrets, credentials, or infra/deployment files changed unless explicitly requested.
+
+## Known CI state (for future runs)
+
+- **All CI jobs that use `./.github/actions/setup-env` (Hooks, Project tests, E2E) currently fail
+  in the `Setup Env` step** with `error: git-hooks or pre-commit-hooks input required`. This is a
+  pre-existing devenv/Nix breakage on `main` (the `git-hooks`/`pre-commit-hooks` flake input is
+  missing from `devenv.yaml`/`devenv.lock`); it is NOT caused by PR changes and reproduces on every
+  recent `main` commit. Do not attempt to fix it for a code/docs task — it requires editing
+  devenv/infra files that are out of scope. Only the **Semantic Pull Request** check (PR title must
+  be a valid Conventional Commit, e.g. `docs:`/`feat:`/`fix:`) can currently go green on a PR.

--- a/SDE-AGENT.md
+++ b/SDE-AGENT.md
@@ -1,0 +1,65 @@
+# SDE Agent instructions — retail-store-sample-app
+
+Additional instructions for the SDE Agent when working autonomously in this repository.
+This file is (1) appended to the agent's prompt as guidance and (2) parsed for the
+circuit-breaker limits below.
+
+## Circuit breakers (parsed; a repo may only tighten below the system caps)
+
+maxTurns: 60
+maxBudgetUsd: 20
+
+## What this repo is
+
+A polyglot microservices retail sample managed as an **Nx monorepo**. Each service lives under
+`src/`:
+
+| Service    | Path             | Stack                    | Build / test tool |
+|------------|------------------|--------------------------|-------------------|
+| ui         | `src/ui`         | Java (Spring)            | Maven (`pom.xml`) |
+| cart       | `src/cart`       | Java (MongoDB/DynamoDB)  | Maven (`pom.xml`) |
+| orders     | `src/orders`     | Java                     | Maven (`pom.xml`) |
+| catalog    | `src/catalog`    | Go                       | `go` / `Makefile` |
+| checkout   | `src/checkout`   | Node (NestJS/TypeScript) | yarn + Nx + Jest  |
+
+Educational sample only — not production. It's a fork of `aws-containers/retail-store-sample-app`.
+
+## How to work here
+
+- **Scope changes tightly to the task.** Touch only the service(s) the task concerns; do not
+  refactor across services or edit unrelated code.
+- **Match existing conventions per service** — Java code follows the existing package/style;
+  TypeScript is formatted with Prettier (`.prettierrc`) and linted with ESLint.
+- **Do NOT modify** deployment/infra unless the task explicitly asks: `terraform/`, Helm charts,
+  `docker-compose*.yaml`, `.github/`, release config (`release-please-config.json`), `renovate.json`.
+- Keep commits focused; write a clear message describing the change.
+
+## Building & testing
+
+This is an Nx monorepo. Prefer running the check for the service you changed:
+
+- **checkout (Node):** from `src/checkout`, run `yarn install` then the relevant script
+  (`yarn build`, `yarn lint`, `yarn test`). Note: unit `test` is currently a no-op (`exit 0`);
+  meaningful tests are `test:integration` (Jest e2e). Don't claim tests passed if you only ran the
+  no-op — say what you actually ran.
+- **catalog (Go):** from `src/catalog`, run `go build ./...` and `go test ./...` (or the `Makefile`
+  targets if present).
+- **ui / cart / orders (Java):** from the service dir, `mvn -q -B verify` (or `mvn test`) if Maven
+  and a JDK are available in the build environment. If the toolchain isn't installed, note that you
+  could not run the Java build rather than assuming success.
+- **Always run the check that corresponds to the code you changed**, and report the actual result.
+
+## Running the app (optional; usually not needed for code tasks)
+
+- The runnable compose lives at `src/app` and needs a DB password:
+  `docker compose --project-directory src/app up --build --detach --wait` (npm: `yarn compose:up`).
+- NOTE: the SDE Agent's automatic dev-deploy only brings up the **root** `docker-compose.yaml`,
+  which requires a `DB_PASSWORD` env var it does not set — so the automatic dev deployment may be
+  partial or skipped. This is non-fatal; only stand the app up yourself if the task specifically
+  requires a running instance (e.g. reproducing a runtime bug), using the `src/app` command above.
+
+## Definition of done
+
+- The change addresses the task and nothing more.
+- The relevant service builds; the relevant tests run (and you report what you ran + the outcome).
+- No secrets, credentials, or infra/deployment files changed unless explicitly requested.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,331 @@
+name: retail-sample
+networks:
+  default:
+    name: retail-sample_default
+services:
+  cart:
+    cap_add:
+      - NET_BIND_SERVICE
+    cap_drop:
+      - all
+    depends_on:
+      carts-db:
+        condition: service_healthy
+        required: true
+    environment:
+      - SERVER_TOMCAT_ACCESSLOG_ENABLED=true
+      - RETAIL_CART_PERSISTENCE_PROVIDER=dynamodb
+      - RETAIL_CART_PERSISTENCE_DYNAMODB_ENDPOINT=http://carts-db:8000
+      - RETAIL_CART_PERSISTENCE_DYNAMODB_CREATE_TABLE=true
+      - AWS_ACCESS_KEY_ID=key
+      - AWS_SECRET_ACCESS_KEY=dummy
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 15s
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:8080/actuator/health || exit 1
+      timeout: 10s
+    hostname: carts
+    networks:
+      default: null
+    ports: []
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid
+    image: public.ecr.aws/aws-containers/retail-store-sample-cart:1.6.1
+  carts-db:
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+    cap_drop:
+      - all
+    healthcheck:
+      interval: 5s
+      retries: 3
+      test:
+        - CMD-SHELL
+        - exit 0
+      timeout: 15s
+    hostname: carts-db
+    image: amazon/dynamodb-local:1.20.0
+    networks:
+      default: null
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid
+  catalog:
+    cap_drop:
+      - all
+    depends_on:
+      catalog-db:
+        condition: service_healthy
+        required: true
+        restart: true
+      opensearch:
+        condition: service_healthy
+        required: true
+        restart: true
+    environment:
+      - GIN_MODE=release
+      - reschedule=on-node-failure
+      - RETAIL_CATALOG_PERSISTENCE_PROVIDER=mysql
+      - RETAIL_CATALOG_PERSISTENCE_PASSWORD=${DB_PASSWORD}
+      - RETAIL_CATALOG_PERSISTENCE_ENDPOINT=catalog-db:3306
+      - RETAIL_CATALOG_SEARCH_ENABLED=${SEARCH_ENABLED:-false}
+      - RETAIL_CATALOG_SEARCH_OS_ENDPOINT=http://opensearch:9200
+      - RETAIL_CATALOG_SEARCH_OS_INDEX=products
+      - RETAIL_CATALOG_SEARCH_OS_TLS_SKIP_VERIFY=true
+    healthcheck:
+      interval: 10s
+      retries: 3
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:8080/health || exit 1
+      timeout: 10s
+    hostname: catalog
+    networks:
+      default: null
+    ports: []
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    image: public.ecr.aws/aws-containers/retail-store-sample-catalog:1.6.1
+  catalog-db:
+    environment:
+      - reschedule=on-node-failure
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+      - MYSQL_DATABASE=catalogdb
+      - MYSQL_USER=catalog_user
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 30s
+      test:
+        - CMD
+        - mysqladmin
+        - ping
+        - -h
+        - localhost
+        - -u
+        - catalog_user
+        - -p${DB_PASSWORD}
+      timeout: 5s
+    hostname: catalog-db
+    image: mariadb:10.9
+    networks:
+      default: null
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+  checkout:
+    cap_add:
+      - NET_BIND_SERVICE
+    cap_drop:
+      - all
+    depends_on:
+      checkout-redis:
+        condition: service_healthy
+        required: true
+    environment:
+      - RETAIL_CHECKOUT_PERSISTENCE_PROVIDER=redis
+      - RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL=redis://checkout-redis:6379
+      - RETAIL_CHECKOUT_ENDPOINTS_ORDERS=http://orders:8080
+    healthcheck:
+      interval: 10s
+      retries: 3
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:8080/health || exit 1
+      timeout: 10s
+    hostname: checkout
+    networks:
+      default: null
+    ports: []
+    read_only: true
+    restart: always
+    tmpfs:
+      - /tmp:rw,noexec,nosuid
+    image: public.ecr.aws/aws-containers/retail-store-sample-checkout:1.6.1
+  checkout-redis:
+    healthcheck:
+      interval: 1s
+      retries: 30
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      timeout: 3s
+    hostname: checkout-redis
+    image: redis:6.0-alpine
+    networks:
+      default: null
+    ports: []
+    restart: always
+  opensearch:
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 60s
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:9200/_cluster/health || exit 1
+      timeout: 10s
+    hostname: opensearch
+    image: opensearchproject/opensearch:3.5.0
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        protocol: tcp
+        published: "9200"
+        target: 9200
+      - mode: ingress
+        protocol: tcp
+        published: "9600"
+        target: 9600
+    restart: always
+    volumes:
+      - source: opensearch-data
+        target: /usr/share/opensearch/data
+        type: volume
+        volume: {}
+  orders:
+    cap_add:
+      - NET_BIND_SERVICE
+    cap_drop:
+      - all
+    depends_on:
+      orders-db:
+        condition: service_healthy
+        required: true
+        restart: true
+    environment:
+      - reschedule=on-node-failure
+      - SERVER_TOMCAT_ACCESSLOG_ENABLED=true
+      - RETAIL_ORDERS_PERSISTENCE_PROVIDER=postgres
+      - RETAIL_ORDERS_PERSISTENCE_ENDPOINT=orders-db:5432
+      - RETAIL_ORDERS_PERSISTENCE_NAME=orders
+      - RETAIL_ORDERS_PERSISTENCE_USERNAME=orders_user
+      - RETAIL_ORDERS_PERSISTENCE_PASSWORD=${DB_PASSWORD}
+      - RETAIL_ORDERS_MESSAGING_PROVIDER=rabbitmq
+      - RETAIL_ORDERS_MESSAGING_RABBITMQ_ADDRESSES=rabbitmq:5672
+      - RETAIL_ORDERS_MESSAGING_RABBITMQ_USERNAME=rabbitmq
+      - RETAIL_ORDERS_MESSAGING_RABBITMQ_PASSWORD=${DB_PASSWORD}
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 15s
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:8080/actuator/health || exit 1
+      timeout: 10s
+    hostname: orders
+    networks:
+      default: null
+    ports: []
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid
+    image: public.ecr.aws/aws-containers/retail-store-sample-orders:1.6.1
+  orders-db:
+    environment:
+      - reschedule=on-node-failure
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=orders
+      - POSTGRES_USER=orders_user
+    healthcheck:
+      interval: 10s
+      retries: 30
+      test:
+        - CMD-SHELL
+        - pg_isready -d orders -U orders_user
+      timeout: 5s
+    hostname: orders-db
+    image: postgres:16.1
+    networks:
+      default: null
+    ports: []
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+  rabbitmq:
+    environment:
+      - RABBITMQ_DEFAULT_USER=rabbitmq
+      - RABBITMQ_DEFAULT_PASS=${DB_PASSWORD}
+    hostname: rabbitmq
+    image: rabbitmq:3-management
+    networks:
+      default: null
+    ports: []
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+  ui:
+    cap_drop:
+      - ALL
+    depends_on:
+      cart:
+        condition: service_healthy
+        required: true
+        restart: true
+      catalog:
+        condition: service_healthy
+        required: true
+        restart: true
+      checkout:
+        condition: service_healthy
+        required: true
+        restart: true
+      orders:
+        condition: service_healthy
+        required: true
+        restart: true
+    environment:
+      - JAVA_OPTS=-XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/urandom
+      - SERVER_TOMCAT_ACCESSLOG_ENABLED=true
+      - RETAIL_UI_SEARCH_ENABLED=${SEARCH_ENABLED:-false}
+      - RETAIL_UI_ENDPOINTS_CATALOG=http://catalog:8080
+      - RETAIL_UI_ENDPOINTS_CARTS=http://carts:8080
+      - RETAIL_UI_ENDPOINTS_ORDERS=http://orders:8080
+      - RETAIL_UI_ENDPOINTS_CHECKOUT=http://checkout:8080
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 15s
+      test:
+        - CMD-SHELL
+        - curl -s -f http://localhost:8080/actuator/health || exit 1
+      timeout: 10s
+    hostname: ui
+    mem_limit: 512m
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        protocol: tcp
+        published: "8888"
+        target: 8080
+    restart: always
+    image: public.ecr.aws/aws-containers/retail-store-sample-ui:1.6.1
+volumes:
+  opensearch-data:
+    name: retail-sample_opensearch-data


### PR DESCRIPTION
## What

Adds a standard `CLAUDE.md` at the repository root to guide Claude Code (and other agentic tooling) when working in this monorepo.

## Contents

- **Overview** of the polyglot microservices retail sample (Nx monorepo, educational only).
- **Repository structure** — per-service table (ui, cart, orders, catalog, checkout) plus notable directories.
- **Common commands** — Nx usage, `nx affected` commands that mirror CI, and per-service build/test instructions.
- **Running the app** — the `src/app` Docker Compose stack and `DB_PASSWORD` requirement.
- **Conventions** — tight scoping, per-service style, enforced Prettier formatting, infra-file guardrails, Conventional Commits.
- **CI checks** — the jobs a PR to `main` runs.

The content is derived from the existing `README.md`, `DEVELOPER_GUIDE.md`, `DEV-DEPLOYMENT.md`, `SDE-AGENT.md`, and the `.github/workflows/` files.

## Notes

- Documentation-only change; no source code touched.
- Verified the file is Prettier-clean (the pre-commit / `devenv test` CI gate).
- A root markdown file is not part of any Nx project, so `nx affected` picks up no targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)