### PR TITLE
feat(ui): add deep /health endpoint pinging downstream services

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import com.amazon.sample.ui.web.util.TopologyInformation;
+import com.amazon.sample.ui.web.util.TopologyService;
+import com.amazon.sample.ui.web.util.TopologyStatus;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Deep health check that pings each downstream service and reports an aggregate
+ * status. Returns 200 when every configured dependency is reachable, or 503 if
+ * any of them is down. Dependencies without a configured endpoint are reported
+ * as DISABLED and do not affect the overall status.
+ */
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+
+  private final EndpointProperties endpoints;
+
+  private final TopologyService topologyService;
+
+  public HealthController(
+    EndpointProperties endpoints,
+    TopologyService topologyService
+  ) {
+    this.endpoints = endpoints;
+    this.topologyService = topologyService;
+  }
+
+  @GetMapping
+  public Mono<ResponseEntity<Map<String, Object>>> health() {
+    return Flux.merge(
+      topologyService.getTopologyForService("catalog", endpoints.getCatalog()),
+      topologyService.getTopologyForService("carts", endpoints.getCarts()),
+      topologyService.getTopologyForService(
+        "checkout",
+        endpoints.getCheckout()
+      ),
+      topologyService.getTopologyForService("orders", endpoints.getOrders())
+    )
+      .collectMap(TopologyInformation::getServiceName, info ->
+        statusLabel(info.getStatus())
+      )
+      .map(dependencies -> {
+        boolean anyDown = dependencies
+          .values()
+          .stream()
+          .anyMatch("DOWN"::equals);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", anyDown ? "DOWN" : "UP");
+        body.put("dependencies", dependencies);
+
+        return ResponseEntity.status(
+          anyDown ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.OK
+        ).body(body);
+      });
+  }
+
+  private static String statusLabel(TopologyStatus status) {
+    return switch (status) {
+      case HEALTHY -> "UP";
+      case UNHEALTHY -> "DOWN";
+      case NONE -> "DISABLED";
+    };
+  }
+}

--- a/src/ui/src/test/java/com/amazon/sample/ui/web/HealthControllerTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/web/HealthControllerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import com.amazon.sample.ui.web.util.TopologyInformation;
+import com.amazon.sample.ui.web.util.TopologyService;
+import com.amazon.sample.ui.web.util.TopologyStatus;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class HealthControllerTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void returnsOkWhenAllConfiguredDependenciesAreHealthy() {
+    var endpoints = endpoints(
+      "http://catalog",
+      "http://carts",
+      "http://checkout",
+      null
+    );
+    var topologyService = mock(TopologyService.class);
+    stub(topologyService, "catalog", "http://catalog", TopologyStatus.HEALTHY);
+    stub(topologyService, "carts", "http://carts", TopologyStatus.HEALTHY);
+    stub(
+      topologyService,
+      "checkout",
+      "http://checkout",
+      TopologyStatus.HEALTHY
+    );
+    stub(topologyService, "orders", null, TopologyStatus.NONE);
+
+    var controller = new HealthController(endpoints, topologyService);
+
+    StepVerifier.create(controller.health())
+      .assertNext(entity -> {
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody().get("status")).isEqualTo("UP");
+        var deps = (Map<String, Object>) entity.getBody().get("dependencies");
+        assertThat(deps)
+          .containsEntry("catalog", "UP")
+          .containsEntry("carts", "UP")
+          .containsEntry("checkout", "UP")
+          .containsEntry("orders", "DISABLED");
+      })
+      .verifyComplete();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void returnsServiceUnavailableWhenADependencyIsDown() {
+    var endpoints = endpoints(
+      "http://catalog",
+      "http://carts",
+      "http://checkout",
+      "http://orders"
+    );
+    var topologyService = mock(TopologyService.class);
+    stub(topologyService, "catalog", "http://catalog", TopologyStatus.HEALTHY);
+    stub(topologyService, "carts", "http://carts", TopologyStatus.HEALTHY);
+    stub(
+      topologyService,
+      "checkout",
+      "http://checkout",
+      TopologyStatus.HEALTHY
+    );
+    stub(topologyService, "orders", "http://orders", TopologyStatus.UNHEALTHY);
+
+    var controller = new HealthController(endpoints, topologyService);
+
+    StepVerifier.create(controller.health())
+      .assertNext(entity -> {
+        assertThat(entity.getStatusCode()).isEqualTo(
+          HttpStatus.SERVICE_UNAVAILABLE
+        );
+        assertThat(entity.getBody().get("status")).isEqualTo("DOWN");
+        var deps = (Map<String, Object>) entity.getBody().get("dependencies");
+        assertThat(deps)
+          .containsEntry("catalog", "UP")
+          .containsEntry("orders", "DOWN");
+      })
+      .verifyComplete();
+  }
+
+  @Test
+  void unconfiguredDependenciesDoNotFailHealth() {
+    var endpoints = endpoints(null, null, null, null);
+    var topologyService = mock(TopologyService.class);
+    stub(topologyService, "catalog", null, TopologyStatus.NONE);
+    stub(topologyService, "carts", null, TopologyStatus.NONE);
+    stub(topologyService, "checkout", null, TopologyStatus.NONE);
+    stub(topologyService, "orders", null, TopologyStatus.NONE);
+
+    var controller = new HealthController(endpoints, topologyService);
+
+    StepVerifier.create(controller.health())
+      .assertNext(entity ->
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK)
+      )
+      .verifyComplete();
+  }
+
+  private void stub(
+    TopologyService topologyService,
+    String service,
+    String endpoint,
+    TopologyStatus status
+  ) {
+    var info = new TopologyInformation();
+    info.setServiceName(service);
+    info.setEndpoint(endpoint);
+    info.setStatus(status);
+    when(
+      topologyService.getTopologyForService(eq(service), eq(endpoint))
+    ).thenReturn(Mono.just(info));
+  }
+
+  private EndpointProperties endpoints(
+    String catalog,
+    String carts,
+    String checkout,
+    String orders
+  ) {
+    var properties = new EndpointProperties();
+    properties.setCatalog(catalog);
+    properties.setCarts(carts);
+    properties.setCheckout(checkout);
+    properties.setOrders(orders);
+    return properties;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a top-level `/health` endpoint to the **UI** service that performs a *deep* health check: it pings each downstream service (catalog, cart, orders, checkout) and returns:

- **200** with a JSON summary of every dependency's status when nothing is down, or
- **503** if any configured dependency is unreachable.

## Behaviour

```jsonc
// GET /health  → 200 (all healthy)
{"status":"UP","dependencies":{"catalog":"UP","carts":"UP","orders":"UP","checkout":"UP"}}

// GET /health  → 503 (a dependency is down)
{"status":"DOWN","dependencies":{"catalog":"DOWN","carts":"UP","orders":"UP","checkout":"UP"}}
```

- Reuses the existing, already-tested `TopologyService` probe logic (`/topology` → `/health` → `/actuator/health`) to determine each dependency's reachability.
- Dependencies **without a configured endpoint** (i.e. the default mock mode used by the single-container e2e deployment) are reported as `DISABLED` and do **not** trigger a 503 — so this does not break the existing e2e stack.
- Distinct from the existing Spring Boot `/actuator/health` (which the Docker healthcheck uses and this change leaves untouched).

## Testing

- `HealthControllerTest` — 3 unit tests covering all-healthy (200), a dependency down (503), and all-unconfigured (200).
- Full UI suite green: `./mvnw test -DexcludedGroups=integration` → 14 tests pass.
- `./mvnw checkstyle:checkstyle` clean; `prettier --check` clean.
- Manually verified against a running UI jar: mock mode → `200`/all `DISABLED`; an unreachable catalog endpoint → `503`/catalog `DOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)