### PR TITLE
fix: restore catalog product price JSON field name

### DIFF
--- a/src/catalog/model/products.go
+++ b/src/catalog/model/products.go
@@ -20,7 +20,7 @@ type Product struct {
 	ID          string `json:"id" gorm:"primaryKey"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Price       int    `json:"cost"`
+	Price       int    `json:"price"`
 	Tags        []Tag  `json:"tags" gorm:"many2many:product_tags;"`
 }
 


### PR DESCRIPTION
## Problem

Every product on the catalog and home page displayed a price of \$0.00 (rendered as `-zsh.00` in the reporter's shell, where `\$0` expands to the shell name). In the cart, line-item prices and the subtotal were also \$0.00, breaking checkout totals. All individual service unit tests passed, so the bug only surfaced when the services ran together.

## Root cause

The bug commit (`cf2d4e9`) renamed the catalog `Product.Price` JSON tag from `price` to `cost`:

```go
Price int `json:"cost"`
```

The catalog service therefore serialized product prices under the key `"cost"`. However, the catalog **OpenAPI contract** (`src/catalog/openapi.yml`) and the UI's generated Kiota client both expect `"price"`. At runtime the UI deserialized a `null` price → `0` → displayed `\$0.00` on the catalog, home page, and cart (line items + subtotal).

Unit tests passed because they exercise the Go struct directly, never the cross-service JSON contract.

## Fix

Restore the JSON tag to `"price"` so the catalog response matches the OpenAPI contract the UI is generated from.

```go
Price int `json:"price"`
```

## Verification

- `go build -o dist/main main.go` — succeeds (Go 1.25).
- `go test ./test/...` — catalog integration tests pass.
- Serialization check confirms the catalog now emits `{"...","price":250,...}` matching the OpenAPI contract.