### PR TITLE
fix(catalog): restore price JSON field name

### DIFF
--- a/src/catalog/model/products.go
+++ b/src/catalog/model/products.go
@@ -20,7 +20,7 @@ type Product struct {
 	ID          string `json:"id" gorm:"primaryKey"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Price       int    `json:"cost"`
+	Price       int    `json:"price"`
 	Tags        []Tag  `json:"tags" gorm:"many2many:product_tags;"`
 }
 


### PR DESCRIPTION
## Summary

Every product showed a price of **\$0.00** on the catalog and home pages, and adding an item made the cart line-item price and subtotal read \$0.00 too, breaking checkout totals.

**Root cause:** the catalog `Product` model serialized its price with the JSON tag `json:"cost"`, so the catalog API emitted `{"cost":250}`. The UI's generated catalog client deserializes the `price` field, so it never found a value and defaulted the price to `0`. That 0 flowed into the catalog/home pages and, via the add-to-cart path (`unitPrice` from the product), into cart line items and the subtotal.

This only surfaced when the services ran together: each service's unit tests operate on their own model (catalog asserts the Go struct directly; the UI uses mocks), so neither caught the broken cross-service contract.

**Fix:** restore the tag to `json:"price"` in `src/catalog/model/products.go` so the API contract matches what the UI expects. One-line change.

## Verification

Reproduced and fixed against the full `docker compose` stack:

- Before: catalog API returned `"cost":10000`; UI catalog page and cart subtotal rendered `$0`.
- After: catalog API returns `"price":10000`; UI catalog page shows real prices (e.g. `$10000`, `$190`), and after adding an item the cart line item and subtotal reflect the real price. Zero `$0` occurrences remain on the cart page.

`gofmt -l` clean; `go build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)