### PR TITLE
feat(ui): add deep health check endpoint

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/services/health/DependencyHealth.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/health/DependencyHealth.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.services.health;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DependencyHealth {
+
+  private String name;
+  private HealthStatus status;
+
+  public boolean isDown() {
+    return status == HealthStatus.DOWN;
+  }
+}

--- a/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthService.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.services.health;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * Performs a deep health check of the UI's downstream dependencies by probing
+ * each service's health endpoint.
+ */
+@Service
+@Slf4j
+public class HealthService {
+
+  private static final int CONNECT_TIMEOUT = 1000;
+  private static final int RESPONSE_TIMEOUT = 1000;
+
+  private final WebClient webClient;
+  private final EndpointProperties endpoints;
+
+  @Autowired
+  public HealthService(
+    WebClient.Builder webClientBuilder,
+    EndpointProperties endpoints
+  ) {
+    HttpClient httpClient = HttpClient.create()
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT)
+      .responseTimeout(Duration.ofMillis(RESPONSE_TIMEOUT));
+
+    this.webClient = webClientBuilder
+      .clientConnector(new ReactorClientHttpConnector(httpClient))
+      .build();
+    this.endpoints = endpoints;
+  }
+
+  HealthService(WebClient webClient, EndpointProperties endpoints) {
+    this.webClient = webClient;
+    this.endpoints = endpoints;
+  }
+
+  public Mono<HealthSummary> checkHealth() {
+    return Flux.merge(
+      checkDependency("catalog", endpoints.getCatalog()),
+      checkDependency("carts", endpoints.getCarts()),
+      checkDependency("orders", endpoints.getOrders()),
+      checkDependency("checkout", endpoints.getCheckout())
+    )
+      .collectList()
+      .map(HealthSummary::new);
+  }
+
+  private Mono<DependencyHealth> checkDependency(String name, String endpoint) {
+    if (endpoint == null || endpoint.isEmpty()) {
+      return Mono.just(new DependencyHealth(name, HealthStatus.UNKNOWN));
+    }
+
+    return checkHealth(endpoint).map(healthy -> {
+      if (!healthy) {
+        log.warn("Health check failed for service {} at {}", name, endpoint);
+      }
+      return new DependencyHealth(
+        name,
+        healthy ? HealthStatus.UP : HealthStatus.DOWN
+      );
+    });
+  }
+
+  private Mono<Boolean> checkHealth(String endpoint) {
+    return probeHealth(joinPath(endpoint, "health")).flatMap(ok ->
+      ok ? Mono.just(true) : probeHealth(joinPath(endpoint, "actuator/health"))
+    );
+  }
+
+  private Mono<Boolean> probeHealth(String url) {
+    return webClient
+      .get()
+      .uri(url)
+      .retrieve()
+      .toBodilessEntity()
+      .map(response -> response.getStatusCode().is2xxSuccessful())
+      .onErrorReturn(false);
+  }
+
+  private String joinPath(String endpoint, String path) {
+    return endpoint.endsWith("/") ? endpoint + path : endpoint + "/" + path;
+  }
+}

--- a/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthStatus.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.services.health;
+
+public enum HealthStatus {
+  UP,
+  DOWN,
+  UNKNOWN,
+}

--- a/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthSummary.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/health/HealthSummary.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.services.health;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class HealthSummary {
+
+  private final HealthStatus status;
+  private final Map<String, HealthStatus> dependencies;
+
+  public HealthSummary(List<DependencyHealth> dependencies) {
+    this.dependencies = dependencies
+      .stream()
+      .collect(
+        Collectors.toMap(
+          DependencyHealth::getName,
+          DependencyHealth::getStatus,
+          (a, b) -> a,
+          LinkedHashMap::new
+        )
+      );
+    this.status = dependencies.stream().anyMatch(DependencyHealth::isDown)
+      ? HealthStatus.DOWN
+      : HealthStatus.UP;
+  }
+
+  @JsonIgnore
+  public boolean isHealthy() {
+    return status != HealthStatus.DOWN;
+  }
+}

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import com.amazon.sample.ui.services.health.HealthService;
+import com.amazon.sample.ui.services.health.HealthSummary;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * Top-level deep health check that pings each downstream service and reports an
+ * aggregate status. Returns 200 when every dependency is reachable, or 503 when
+ * any dependency is down.
+ */
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+
+  @Autowired
+  private HealthService healthService;
+
+  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  public Mono<ResponseEntity<HealthSummary>> health() {
+    return healthService
+      .checkHealth()
+      .map(summary ->
+        ResponseEntity.status(
+          summary.isHealthy() ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE
+        ).body(summary)
+      );
+  }
+}

--- a/src/ui/src/test/java/com/amazon/sample/ui/services/health/HealthServiceTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/services/health/HealthServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.services.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class HealthServiceTest {
+
+  @Test
+  void reportsUpWhenAllDependenciesRespond() {
+    var recorder = new RequestRecorder(req -> response(HttpStatus.OK));
+    var service = new HealthService(buildClient(recorder), allEndpoints());
+
+    StepVerifier.create(service.checkHealth())
+      .assertNext(summary -> {
+        assertThat(summary.getStatus()).isEqualTo(HealthStatus.UP);
+        assertThat(summary.isHealthy()).isTrue();
+        assertThat(summary.getDependencies())
+          .containsEntry("catalog", HealthStatus.UP)
+          .containsEntry("carts", HealthStatus.UP)
+          .containsEntry("orders", HealthStatus.UP)
+          .containsEntry("checkout", HealthStatus.UP);
+      })
+      .verifyComplete();
+  }
+
+  @Test
+  void fallsBackToActuatorHealthWhenHealthIsMissing() {
+    var recorder = new RequestRecorder(req ->
+      req.url().getPath().equals("/actuator/health")
+        ? response(HttpStatus.OK)
+        : response(HttpStatus.NOT_FOUND)
+    );
+    var service = new HealthService(buildClient(recorder), allEndpoints());
+
+    StepVerifier.create(service.checkHealth())
+      .assertNext(summary ->
+        assertThat(summary.getStatus()).isEqualTo(HealthStatus.UP)
+      )
+      .verifyComplete();
+  }
+
+  @Test
+  void reportsDownWhenAnyDependencyIsUnreachable() {
+    var recorder = new RequestRecorder(req ->
+      req.url().getHost().equals("orders")
+        ? response(HttpStatus.INTERNAL_SERVER_ERROR)
+        : response(HttpStatus.OK)
+    );
+    var service = new HealthService(buildClient(recorder), allEndpoints());
+
+    StepVerifier.create(service.checkHealth())
+      .assertNext(summary -> {
+        assertThat(summary.getStatus()).isEqualTo(HealthStatus.DOWN);
+        assertThat(summary.isHealthy()).isFalse();
+        assertThat(summary.getDependencies())
+          .containsEntry("orders", HealthStatus.DOWN)
+          .containsEntry("catalog", HealthStatus.UP);
+      })
+      .verifyComplete();
+  }
+
+  @Test
+  void reportsUnknownWhenEndpointNotConfigured() {
+    var recorder = new RequestRecorder(req -> response(HttpStatus.OK));
+    var endpoints = new EndpointProperties();
+    endpoints.setCatalog("http://catalog");
+    var service = new HealthService(buildClient(recorder), endpoints);
+
+    StepVerifier.create(service.checkHealth())
+      .assertNext(summary -> {
+        assertThat(summary.getStatus()).isEqualTo(HealthStatus.UP);
+        assertThat(summary.getDependencies())
+          .containsEntry("catalog", HealthStatus.UP)
+          .containsEntry("carts", HealthStatus.UNKNOWN)
+          .containsEntry("orders", HealthStatus.UNKNOWN)
+          .containsEntry("checkout", HealthStatus.UNKNOWN);
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedHosts).containsOnly("catalog");
+  }
+
+  private static EndpointProperties allEndpoints() {
+    var endpoints = new EndpointProperties();
+    endpoints.setCatalog("http://catalog");
+    endpoints.setCarts("http://carts");
+    endpoints.setOrders("http://orders");
+    endpoints.setCheckout("http://checkout");
+    return endpoints;
+  }
+
+  private WebClient buildClient(ExchangeFunction exchange) {
+    return WebClient.builder().exchangeFunction(exchange).build();
+  }
+
+  private static Mono<ClientResponse> response(HttpStatus status) {
+    return Mono.just(ClientResponse.create(status).body("").build());
+  }
+
+  private static class RequestRecorder implements ExchangeFunction {
+
+    final List<String> requestedHosts = new ArrayList<>();
+    private final Function<ClientRequest, Mono<ClientResponse>> handler;
+
+    RequestRecorder(Function<ClientRequest, Mono<ClientResponse>> handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    public Mono<ClientResponse> exchange(ClientRequest request) {
+      requestedHosts.add(request.url().getHost());
+      return handler.apply(request);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a top-level `/health` endpoint to the UI service that performs a **deep health check** by pinging each downstream service (catalog, cart, orders, checkout).

- Returns **200** with a JSON summary of each dependency's status when all dependencies are reachable.
- Returns **503** when any dependency is down.

Example response:

```json
{"dependencies":{"catalog":"UP","carts":"UP","orders":"UP","checkout":"UP"},"status":"UP"}
```

## Implementation

- `HealthController` (`/health`) — a WebFlux `@RestController` that maps the aggregate result to `200`/`503`.
- `HealthService` — probes each configured downstream, reusing the same probe strategy as the existing `TopologyService` (tries `/health`, falls back to `/actuator/health`) so it works across the mixed health-endpoint conventions of the services. Unconfigured endpoints report `UNKNOWN` and don't fail the check.
- `HealthSummary` / `DependencyHealth` / `HealthStatus` — result models.

Scope is limited to the UI service; no existing code, infra, or deployment files were modified.

## Testing

- Unit tests (`HealthServiceTest`) cover all-up, `/actuator/health` fallback, a dependency down (→ `DOWN`), and unconfigured endpoints (→ `UNKNOWN`).
- `./mvnw test` (15 tests) and `./mvnw checkstyle:check` pass; Prettier clean.
- Verified end-to-end against the full Docker Compose stack: all services up → `200`; a stopped downstream → `503`.

Resolves #16