### PR TITLE
feat(monitoring): add deep /health endpoint to UI service

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/HealthController.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import com.amazon.sample.ui.web.util.TopologyInformation;
+import com.amazon.sample.ui.web.util.TopologyService;
+import com.amazon.sample.ui.web.util.TopologyStatus;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Top-level deep health check for the UI service. Pings each downstream
+ * dependency and returns 200 with a JSON summary of every dependency's status,
+ * or 503 if any dependency is down.
+ */
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+
+  private final EndpointProperties endpoints;
+  private final TopologyService topologyService;
+
+  @Autowired
+  public HealthController(
+    EndpointProperties endpoints,
+    TopologyService topologyService
+  ) {
+    this.endpoints = endpoints;
+    this.topologyService = topologyService;
+  }
+
+  @GetMapping
+  public Mono<ResponseEntity<Map<String, Object>>> health() {
+    return Flux.merge(
+      check("catalog", endpoints.getCatalog()),
+      check("cart", endpoints.getCarts()),
+      check("orders", endpoints.getOrders()),
+      check("checkout", endpoints.getCheckout())
+    )
+      .collectMap(TopologyInformation::getServiceName, this::describe)
+      .map(dependencies -> {
+        boolean allHealthy = dependencies
+          .values()
+          .stream()
+          .noneMatch("DOWN"::equals);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", allHealthy ? "UP" : "DOWN");
+        body.put("dependencies", dependencies);
+
+        return ResponseEntity.status(
+          allHealthy ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE
+        ).body(body);
+      });
+  }
+
+  private Mono<TopologyInformation> check(String serviceName, String endpoint) {
+    return topologyService.getTopologyForService(serviceName, endpoint);
+  }
+
+  private String describe(TopologyInformation info) {
+    if (info.getStatus() == TopologyStatus.HEALTHY) {
+      return "UP";
+    }
+    if (info.getStatus() == TopologyStatus.UNHEALTHY) {
+      return "DOWN";
+    }
+    return "UNKNOWN";
+  }
+}

--- a/src/ui/src/test/java/com/amazon/sample/ui/web/HealthControllerTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/web/HealthControllerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazon.sample.ui.config.EndpointProperties;
+import com.amazon.sample.ui.web.util.TopologyInformation;
+import com.amazon.sample.ui.web.util.TopologyService;
+import com.amazon.sample.ui.web.util.TopologyStatus;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class HealthControllerTest {
+
+  private EndpointProperties endpoints;
+  private TopologyService topologyService;
+  private HealthController controller;
+
+  @BeforeEach
+  void setUp() {
+    endpoints = new EndpointProperties();
+    endpoints.setCatalog("http://catalog");
+    endpoints.setCarts("http://carts");
+    endpoints.setOrders("http://orders");
+    endpoints.setCheckout("http://checkout");
+
+    topologyService = mock(TopologyService.class);
+    controller = new HealthController(endpoints, topologyService);
+  }
+
+  private void stub(
+    String serviceName,
+    String endpoint,
+    TopologyStatus status
+  ) {
+    var info = new TopologyInformation();
+    info.setServiceName(serviceName);
+    info.setEndpoint(endpoint);
+    info.setStatus(status);
+    when(
+      topologyService.getTopologyForService(eq(serviceName), eq(endpoint))
+    ).thenReturn(Mono.just(info));
+  }
+
+  @Test
+  void returns200AndUpWhenAllDependenciesHealthy() {
+    stub("catalog", "http://catalog", TopologyStatus.HEALTHY);
+    stub("cart", "http://carts", TopologyStatus.HEALTHY);
+    stub("orders", "http://orders", TopologyStatus.HEALTHY);
+    stub("checkout", "http://checkout", TopologyStatus.HEALTHY);
+
+    StepVerifier.create(controller.health())
+      .assertNext(response -> {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(body(response).get("status")).isEqualTo("UP");
+        assertThat(dependencies(response))
+          .containsEntry("catalog", "UP")
+          .containsEntry("cart", "UP")
+          .containsEntry("orders", "UP")
+          .containsEntry("checkout", "UP");
+      })
+      .verifyComplete();
+  }
+
+  @Test
+  void returns503AndDownWhenAnyDependencyUnhealthy() {
+    stub("catalog", "http://catalog", TopologyStatus.HEALTHY);
+    stub("cart", "http://carts", TopologyStatus.HEALTHY);
+    stub("orders", "http://orders", TopologyStatus.UNHEALTHY);
+    stub("checkout", "http://checkout", TopologyStatus.HEALTHY);
+
+    StepVerifier.create(controller.health())
+      .assertNext(response -> {
+        assertThat(response.getStatusCode()).isEqualTo(
+          HttpStatus.SERVICE_UNAVAILABLE
+        );
+        assertThat(body(response).get("status")).isEqualTo("DOWN");
+        assertThat(dependencies(response))
+          .containsEntry("catalog", "UP")
+          .containsEntry("orders", "DOWN");
+      })
+      .verifyComplete();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> body(ResponseEntity<Map<String, Object>> resp) {
+    return resp.getBody() == null ? new HashMap<>() : resp.getBody();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, String> dependencies(
+    ResponseEntity<Map<String, Object>> resp
+  ) {
+    return (Map<String, String>) body(resp).get("dependencies");
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #19. Adds a top-level `/health` endpoint to the **UI** service that performs a *deep* health check by pinging each downstream dependency (catalog, cart, orders, checkout).

- Returns **200** with a JSON summary of each dependency's status when all are reachable.
- Returns **503** with the same summary if any dependency is down.

Example response:

```json
{"status":"UP","dependencies":{"catalog":"UP","cart":"UP","orders":"UP","checkout":"UP"}}
```

## Implementation

- New `HealthController` (`@RestController` at `/health`) reuses the existing, already-tested reactive `TopologyService`, which probes each service's `/topology` endpoint and falls back to `/health` / `/actuator/health`. This keeps the change minimal and consistent with how the existing `/topology` page already checks dependencies.
- A dependency reporting `HEALTHY` maps to `UP`; `UNHEALTHY` maps to `DOWN` (drives the 503); a service with no configured endpoint maps to `UNKNOWN`.

## Testing

- `./mvnw test -DexcludedGroups=integration` — all 13 tests pass, including 2 new `HealthControllerTest` cases (all-up → 200/UP, one-down → 503/DOWN).
- Checkstyle (`./mvnw checkstyle:checkstyle`) and Prettier (`yarn prettier --check`) clean.
- Verified end-to-end against the local docker-compose stack: all services healthy → 200; stopping `orders` → 503 with `"orders":"DOWN"`.

---
Opened by the SDE Agent — please review; do not merge without review.